### PR TITLE
Added spherical panorama example

### DIFF
--- a/examples/spherical_panorama/spherical_panorama.html
+++ b/examples/spherical_panorama/spherical_panorama.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html><html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="utf-8">
+
+    <title>Spherical Panorama THREE test</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: #000000;
+        }
+        #three-box canvas {
+            display: block;
+            margin: auto;
+            padding: 0;
+            border : 0;
+        }
+    </style>
+    <script src="../../vendor/lodash.min.js"></script>
+    <script src="../../vendor/three.js"></script>
+    <script src="../../build/react-three.js"></script>
+    <script src="spherical_panorama.js"></script>
+</head>
+<body>
+    <div id="three-box"></div>
+    <script>
+    window.onload = spherepanoramaexamplestart;
+    </script>
+ </body>
+</html>

--- a/examples/spherical_panorama/spherical_panorama.js
+++ b/examples/spherical_panorama/spherical_panorama.js
@@ -1,0 +1,88 @@
+// A simple SphericalPanorama viewer
+
+/* jshint strict: false */
+/* global React : false */
+/* global ReactTHREE : false */
+
+var sphereGeometry = new THREE.SphereGeometry(100, 32, 32);
+
+var imageMaterial =  new THREE.MeshBasicMaterial({
+    map: THREE.ImageUtils.loadTexture('/examples/assets/spherePanorama.jpg')
+});
+
+var SpherePanoramaScene = React.createClass({
+    displayName: 'SpherePanoramaScene',
+    render: function() {
+        var sceneProps = {
+            width: this.props.width,
+            height: this.props.height,
+            camera: 'maincamera',
+        };
+
+        var cameraAngle = this.props.cameraAngle || 0;
+        var cameraLookAt = new THREE.Vector3(
+            Math.cos(cameraAngle),
+            0,
+            Math.sin(cameraAngle)
+        );
+
+        var mainCamera = React.createElement(
+            ReactTHREE.PerspectiveCamera,
+            {
+                name: 'maincamera',
+                aspect: this.props.width / this.props.height,
+                near: 1,
+                far: 5000,
+                position: new THREE.Vector3(0, 0, 0),
+                lookat: cameraLookAt,
+            }
+        );
+
+        var sphere = React.createElement(
+            ReactTHREE.Mesh,
+            {
+                geometry: sphereGeometry,
+                material: imageMaterial,
+                position: new THREE.Vector3(0, 0, 0),
+                scale: new THREE.Vector3(1, 1, -1),
+                quaternion: new THREE.Quaternion(),
+            }
+        );
+
+        return React.createElement(
+            ReactTHREE.Scene,
+            sceneProps,
+            mainCamera,
+            sphere
+        );
+    }
+});
+
+
+/* jshint unused:false */
+function spherepanoramaexamplestart() {
+    var renderelement = document.getElementById("three-box");
+    var appState = {
+        width: window.innerWidth,
+        height: window.innerHeight,
+        cameraAngle: 0,
+    };
+
+    var reactInstance = React.render(
+        React.createElement(SpherePanoramaScene, appState),
+        renderelement
+    );
+
+    var start = Date.now();
+    var PERIOD = 30;
+
+    function animate(time) {
+        var dt = time - start;
+        var newAngle = (2 * dt / (PERIOD * 1000)) * Math.PI;
+        appState.cameraAngle = newAngle;
+        reactInstance.setProps(appState);
+        requestAnimationFrame(animate);
+    }
+
+    animate(start);
+}


### PR DESCRIPTION
I add a simple example of the camera rotating within a sphere wrapped in an image, which allows viewing of spherical panoramas.

Tested in Chrome and Firefox on Ubuntu x86_64.

Screenshot:
![20150109-001122_capture](https://cloud.githubusercontent.com/assets/1941415/5675753/3c681976-9794-11e4-8382-6cb5379c2f67.gif)