### PR TITLE
[ReactTHREE] Antialias the WebGL Renderer by default

### DIFF
--- a/src/ReactTHREE.js
+++ b/src/ReactTHREE.js
@@ -317,7 +317,10 @@ var THREEScene = createTHREEComponent(
       this._THREEObject3D = new THREE.Scene();
 
       this._THREErenderer = Detector.webgl ?
-        new THREE.WebGLRenderer({canvas:renderelement}) :
+        new THREE.WebGLRenderer({
+          canvas:renderelement,
+          antialias: props.antialias === undefined ? true : props.antialias
+        }) :
         new THREE.CanvasRenderer({canvas:renderelement});
       this._THREErenderer.setSize(+props.width, +props.height);
       this._THREEprojector = new THREE.Projector();


### PR DESCRIPTION
Three.JS supports antialiasing as a parameter passed into its Renderer, but it's false by default.

A lot of modern hardware supports antialiasing now and it makes the WebGL views look a lot better. Compare before and after:

before:
![screen shot 2015-01-19 at 8 55 26 pm](https://cloud.githubusercontent.com/assets/1135007/5812686/85d66b92-a024-11e4-8ecf-d1d6544d28de.png)

after:
![screen shot 2015-01-19 at 8 54 59 pm](https://cloud.githubusercontent.com/assets/1135007/5812683/818cc8ec-a024-11e4-9ce3-dc657c0d3058.png)

I decided to enable this for all ThreeSCENE's by default (unless you pass in `false` in the props) but could just match the existing behavior and only check for the prop.

More info here:
http://benchung.com/antialiasing-three-js/

Open to ideas about testing -- unfortunately the param gets passed into the `WebGLRenderer` and is then gobbled up by a private variable, so it's not like we can read it back out after init :-/