### PR TITLE
Use global THREE if available

### DIFF
--- a/src/ReactTHREE.js
+++ b/src/ReactTHREE.js
@@ -22,7 +22,7 @@
 "use strict";
 
 var React = require('react');
-var THREE = require('three');
+var THREE = window.THREE || require('three');
 
 var ReactMount = require('react/lib/ReactMount');
 var ReactUpdates = require('react/lib/ReactUpdates');


### PR DESCRIPTION
Hi. 

You were spot on - the problem I was having was that I had two instances of THREE:

 - The one that I was pulling in as a standalone script so I could use it in a global way (in order that I could then pull in THREE.ColladaLoader)
 - And the NPM one being required by react-three.

At first I tried switching to just use the NPM one, but I would have had to rewrite the ColladaLoader to be CommonJS compatible. (NB. They're working on this: https://github.com/mrdoob/three.js/issues/4776).
Easier and I think more preferable for now is for me to continue with the recommended browserify-shim way and pull THREE and ColladaLoader in as separate scripts and expose them as globals.

So... Please may I edit this line? All it should do is use the global instance of THREE if available, otherwise require as normal.

This is working for me now, for my react-three-demo.