### PR TITLE
Fixes for SkinnedMesh errors

### DIFF
--- a/src/ReactTHREE.js
+++ b/src/ReactTHREE.js
@@ -436,7 +436,7 @@ var THREEScene = React.createClass({
 
     if (firstintersection !== null) {
       var pickobject = firstintersection.object;
-      if (typeof pickobject.userData !== 'undefined') {
+      if (typeof pickobject.userData !== 'undefined' && pickobject.userData._currentElement) {
 	var onpickfunction = pickobject.userData._currentElement.props.onPick;
 	if (typeof onpickfunction === 'function') {
 	  onpickfunction(event, firstintersection);
@@ -679,11 +679,11 @@ var THREESkinnedMesh = createTHREEComponent(
     // skinned mesh is special since it needs the geometry and material data upon construction
     /* jshint unused: vars */
     mountComponent: function(rootID, transaction, context) {
-      this._THREEObject3D = new THREE.SkinnedMesh(this.props.geometry, this.props.material);
-      this.applyTHREEObject3DProps({}, this.props);
-      this.applySpecificTHREEProps({}, this.props);
+      this._THREEObject3D = new THREE.SkinnedMesh(this._currentElement.props.geometry, this._currentElement.props.material);
+      this.applyTHREEObject3DProps({}, this._currentElement.props);
+      this.applySpecificTHREEProps({}, this._currentElement.props);
 
-      this.mountAndAddChildren(this.props.children, transaction, context);
+      this.mountAndAddChildren(this._currentElement.props.children, transaction, context);
       return this._THREEObject3D;
     },
     /* jshint unused: true */


### PR DESCRIPTION
Hi again.

I'm trying out SkinnedMesh now, but ran into some problems. 

Firstly, just trying to create the React component gave:
> "Uncaught TypeError: Cannot read property 'geometry' of undefined" - ReactTHREE.js line 704

`this.props` is undefined there, but I found them under `this._currentElement`.

Secondly, clicking on the page then gave another error:
> "Uncaught TypeError: Cannot read property 'props' of undefined" - ReactTHREE.js line 440

`pickobject.userData` is not undefined, but there is no `pickobject.userData._currentElement`.

The changes here my well be naive, but I made them to my own version to bypass those errors, so thought I may as well make a PR rather than simply an Issue, and see what you think...
