### PR TITLE
pointerEvents prop replaces listenToClick

### DIFF
--- a/examples/camera-up/camera-up.js
+++ b/examples/camera-up/camera-up.js
@@ -136,7 +136,7 @@ var ClickToRemoveCube = React.createClass({
   render: function() {
     var cubeprops = _.clone(this.props);
     cubeprops.materialname = 'lollipopGreen.png';
-    cubeprops.onPick = this.removeThisCube;
+    cubeprops.onClick3D = this.removeThisCube;
     return React.createElement(ClickableCube, cubeprops);
   }
 });
@@ -157,7 +157,7 @@ var CubeAppButtons = React.createClass({
     return React.createElement(
       ReactTHREE.Object3D,
       {},
-      React.createElement(ClickableCube,{position: new THREE.Vector3(0,0,0), materialname:'cherry.png', name:'addbutton', onPick:this.handlePick})
+      React.createElement(ClickableCube,{position: new THREE.Vector3(0,0,0), materialname:'cherry.png', name:'addbutton', onClick3D:this.handlePick})
     );
   }
 });
@@ -271,7 +271,7 @@ var CubeApp = React.createClass({
   render: function() {
     return React.createElement(
       ReactTHREE.Scene,
-      {width: this.state.width, height: this.state.height, listenToClick: true, background:0x202020, camera:'maincamera'},
+      {width: this.state.width, height: this.state.height, pointerEvents: ['onClick'], background:0x202020, camera:'maincamera'},
       [
         React.createElement(OrbitCamera, {key:'camera', distance:600, azimuth:this.state.cameraazimuth, tilt:this.state.cameratilt, aspectratio:this.state.width / this.state.height}),
         React.createElement(RemovableCubes, {key:'cubes', cubes:this.props.cubes}),

--- a/examples/interactive/interactive.js
+++ b/examples/interactive/interactive.js
@@ -135,7 +135,7 @@ var ClickToRemoveCube = React.createClass({
   render: function() {
     var cubeprops = _.clone(this.props);
     cubeprops.materialname = 'lollipopGreen.png';
-    cubeprops.onPick = this.removeThisCube;
+    cubeprops.onMouseMove3D = this.removeThisCube;
     return React.createElement(ClickableCube, cubeprops);
   }
 });
@@ -156,7 +156,7 @@ var CubeAppButtons = React.createClass({
     return React.createElement(
       ReactTHREE.Object3D,
       {},
-      React.createElement(ClickableCube,{position: new THREE.Vector3(0,0,0), materialname:'cherry.png', name:'addbutton', onPick:this.handlePick})
+      React.createElement(ClickableCube,{position: new THREE.Vector3(0,0,0), materialname:'cherry.png', name:'addbutton', onClick3D:this.handlePick})
     );
   }
 });
@@ -264,7 +264,7 @@ var CubeApp = React.createClass({
   render: function() {
     return React.createElement(
       ReactTHREE.Scene,
-      {width: this.state.width, height: this.state.height, listenToClick: true, background:0x202020, camera:'maincamera'},
+      {width: this.state.width, height: this.state.height, pointerEvents: ['onClick', 'onMouseMove'], background:0x202020, camera:'maincamera'},
       [
         React.createElement(OrbitCamera, {key:'camera', distance:600, azimuth:this.state.cameraazimuth, aspectratio:this.state.width / this.state.height}),
         React.createElement(RemovableCubes, {key:'cubes', cubes:this.props.cubes}),
@@ -277,7 +277,7 @@ var CubeApp = React.createClass({
 
 
 function interactiveexamplestart() { // eslint-disable-line no-unused-vars
-  
+
   g_renderelement = document.getElementById("three-box");
 
   g_applicationstate = {borderpx:6, cubes:[], xsize:500, ysize:500, zsize:500 };


### PR DESCRIPTION
this adds support for any pointer event
pointerEvents prop expects an array of react event names.
for example, `['onClick', 'onMouseMove']`

I've changed the interactive example to remove added cubes when you *mouse move* over them.

Whatever the event name, the event handler prop will be appended with `3D`. This replaces `onPick`. So instead of using `onPick` you would use `onClick3D`. And if you need `onMouseMove`, you would use `onMouseMove3D`

btw, maybe there's a better name that `pointerEvents`? Might confuse people since `pointer-events` is a css property.

