### PR TITLE
Create THREERenderer and decouple Renderer from THREEScene

### DIFF
--- a/examples/cupcake/cupcake.js
+++ b/examples/cupcake/cupcake.js
@@ -52,11 +52,19 @@ var ExampleScene = React.createClass({
       ReactTHREE.PerspectiveCamera,
       {name:'maincamera', fov:'75', aspect:this.props.width/this.props.height, near:1, far:5000, position:new THREE.Vector3(0,0,600), lookat:new THREE.Vector3(0,0,0)});
 
-    return React.createElement(
-      ReactTHREE.Scene,
-      {width:this.props.width, height:this.props.height, camera:'maincamera'},
-      MainCameraElement,
-      React.createElement(Cupcake, this.props.cupcakedata)
+    return (
+        React.createElement(ReactTHREE.Renderer, { disableHotLoader: true, width:this.props.width, height:this.props.height },
+            React.createElement(ReactTHREE.Scene,
+                {disableHotLoader:true, width:this.props.width, height:this.props.height, camera:'maincamera'}
+                ,MainCameraElement
+                ,React.createElement(Cupcake, this.props.cupcakedata)
+            ),
+            React.createElement(ReactTHREE.Scene,
+                {disableHotLoader:true, width:this.props.width, height:this.props.height, camera:'maincamera'}
+                ,MainCameraElement
+                ,React.createElement(Cupcake, this.props.cupcakedata2)
+            )
+        )
     );
   }
 });
@@ -67,8 +75,12 @@ var cupcakestart = function() { // eslint-disable-line no-unused-vars
   var w = window.innerWidth-6;
   var h = window.innerHeight-6;
 
-  var sceneprops = {width:w, height:h, cupcakedata:{position:new THREE.Vector3(0,0,0), quaternion:new THREE.Quaternion()}};
+  var sceneprops = {width:w, height:h,
+    cupcakedata:{position:new THREE.Vector3(0,0,0), quaternion:new THREE.Quaternion()},
+    cupcakedata2:{position:new THREE.Vector3(0,0,0), quaternion:new THREE.Quaternion()}
+  };
   var cupcakeprops = sceneprops.cupcakedata;
+  var cupcakeprops2 = sceneprops.cupcakedata2;
   var rotationangle = 0;
 
   ReactTHREE.render(React.createElement(ExampleScene,sceneprops), renderelement);
@@ -77,7 +89,9 @@ var cupcakestart = function() { // eslint-disable-line no-unused-vars
     rotationangle = t * 0.001;
     cupcakeprops.quaternion.setFromEuler(new THREE.Euler(rotationangle,rotationangle*3,0));
     cupcakeprops.position.x = 300  * Math.sin(rotationangle);
-    
+    cupcakeprops2.quaternion.setFromEuler(new THREE.Euler(rotationangle,rotationangle*3,0));
+    cupcakeprops2.position.x = 300  * Math.sin(-rotationangle);
+
     ReactTHREE.render(React.createElement(ExampleScene,sceneprops), renderelement);
 
     requestAnimationFrame(spincupcake);

--- a/src/ReactTHREE.js
+++ b/src/ReactTHREE.js
@@ -26,6 +26,7 @@ var monkeypatch = require('./ReactTHREEMonkeyPatch');
 monkeypatch();
 
 module.exports =  {
+    Renderer : require('./components/THREERenderer'),
     Scene : require('./components/THREEScene'),
     PerspectiveCamera : require('./components/cameras/THREEPerspectiveCamera'),
     OrthographicCamera : require('./components/cameras/THREEOrthographicCamera'),

--- a/src/components/THREERenderer.js
+++ b/src/components/THREERenderer.js
@@ -1,0 +1,190 @@
+const React = require('react');
+const ReactDOM = require('react-dom');
+const ReactMount = require('react/lib/ReactMount');
+const ReactUpdates = require('react/lib/ReactUpdates');
+const warning = require('fbjs/lib/warning');
+const THREE = require('three');
+const THREEContainerMixin = require('../mixins/THREEContainerMixin');
+const THREEObject3DMixin = require('../mixins/THREEObject3DMixin');
+
+const ReactBrowserEventEmitter = require('react/lib/ReactBrowserEventEmitter');
+const putListener = ReactBrowserEventEmitter.putListener;
+const listenTo = ReactBrowserEventEmitter.listenTo;
+
+const ELEMENT_NODE_TYPE = 1; // some stuff isn't exposed by ReactDOMComponent
+
+//
+// The 'Scene' component includes both the three.js scene and
+// the canvas DOM element that three.js renders onto.
+//
+
+const THREERenderer = React.createClass({
+    displayName: 'THREERenderer',
+    mixins: [THREEContainerMixin],
+
+    propTypes: {
+        enableRapidRender: React.PropTypes.bool,
+        pixelRatio: React.PropTypes.number,
+        pointerEvents: React.PropTypes.arrayOf(React.PropTypes.string),
+        transparent: React.PropTypes.bool,
+        disableHotLoader: React.PropTypes.bool
+    },
+
+    getDefaultProps() {
+        return {
+            enableRapidRender: true,
+            pixelRatio: 1,
+            transparent: false,
+            disableHotLoader: false
+        };
+    },
+
+    componentDidMount() {
+        const renderelement = this.props.canvas || ReactDOM.findDOMNode(this);
+        const props = this.props;
+        const context = this._reactInternalInstance._context;
+
+        this._THREErenderer = new THREE.WebGLRenderer({
+            alpha: this.props.transparent,
+            canvas: renderelement,
+            antialias: props.antialias === undefined ? true : props.antialias
+        });
+        this._THREErenderer.shadowMap.enabled = props.shadowMapEnabled !== undefined ? props.shadowMapEnabled : false;
+        if (props.shadowMapType !== undefined) {
+            this._THREErenderer.shadowMap.type = props.shadowMapType;
+        }
+        this._THREErenderer.setPixelRatio(props.pixelRatio);
+        this._THREErenderer.setSize(+props.width, +props.height);
+        this._THREEraycaster = new THREE.Raycaster();
+
+        const transaction = ReactUpdates.ReactReconcileTransaction.getPooled();
+        transaction.perform(
+            this.mountAndAddChildren,
+            this,
+            props.children,
+            transaction,
+        	  context
+        );
+        ReactUpdates.ReactReconcileTransaction.release(transaction);
+
+        // hack for react-hot-loader
+        if (!this.props.disableHotLoader) {
+          this._reactInternalInstance._renderedComponent._renderedChildren = this._renderedChildren;
+        }
+
+        const backgroundtype = typeof props.background;
+        if (backgroundtype !== 'undefined') {
+            // background color should be a number, check it
+            warning(backgroundtype === 'number', "The background property of "+
+                "the Renderer component must be a number, not " + backgroundtype);
+            this._THREErenderer.setClearColor(props.background, this.props.transparent ? 0 : 1);
+        }
+
+        this.renderScene();
+
+        // The canvas gets re-rendered every frame even if no props/state changed.
+        // This is because some three.js items like skinned meshes need redrawing
+        // every frame even if nothing changed in React props/state.
+        //
+        // See https://github.com/Izzimach/react-three/issues/28
+
+        if (this.props.enableRapidRender) {
+            const rapidrender = (timestamp) => {
+
+                this._timestamp = timestamp;
+                this._rAFID = window.requestAnimationFrame( rapidrender );
+
+                // render the stage
+                this.renderScene();
+            }
+
+            this._rAFID = window.requestAnimationFrame( rapidrender );
+        }
+
+        // warn users of the old listenToClick prop
+        warning(typeof props.listenToClick === 'undefined', "the `listenToClick` prop has been replaced with `pointerEvents`");
+
+        renderelement.onselectstart = function() { return false; };
+    },
+
+    componentDidUpdate(oldProps) {
+        const props = this.props;
+        const context = this._reactInternalInstance._context;
+
+        if (props.pixelRatio != oldProps.pixelRatio) {
+            this._THREErenderer.setPixelRatio(props.pixelRatio);
+        }
+
+        if (props.width != oldProps.width ||
+            props.width != oldProps.height ||
+            props.pixelRatio != oldProps.pixelRatio) {
+            this._THREErenderer.setSize(+props.width, +props.height);
+        }
+
+        const backgroundtype = typeof props.background;
+        if (backgroundtype !== 'undefined') {
+            // background color should be a number, check it
+            warning(backgroundtype === 'number', "The background property of "+
+                "the scene component must be a number, not " + backgroundtype);
+            this._THREErenderer.setClearColor(props.background, this.props.transparent ? 0 : 1);
+        }
+
+        const transaction = ReactUpdates.ReactReconcileTransaction.getPooled();
+        transaction.perform(
+            this.updateChildren,
+            this,
+            this.props.children,
+            transaction,
+        	  context
+        );
+        ReactUpdates.ReactReconcileTransaction.release(transaction);
+        
+        // hack for react-hot-loader
+        if (!this.props.disableHotLoader) {
+            this._reactInternalInstance._renderedComponent._renderedChildren = this._renderedChildren;
+        }
+
+        this.renderScene();
+    },
+
+    componentWillUnmount() {
+        // hack for react-hot-loader
+        if (!this.props.disableHotLoader) {
+          this._reactInternalInstance._renderedComponent._renderedChildren = null;
+        }
+        this.unmountChildren();
+        ReactBrowserEventEmitter.deleteAllListeners(this._reactInternalInstance._rootNodeID);
+        if (typeof this._rAFID !== 'undefined') {
+            window.cancelAnimationFrame(this._rAFID);
+        }
+    },
+
+    renderScene() {
+        if (!this.props.children) return;
+
+        const children = this._renderedChildren;
+
+        this._THREErenderer.autoClear = false;
+        this._THREErenderer.clear();
+
+        Object.keys(children).forEach(key => {
+          const scene = children[key]._instance;
+          if (scene._THREEObject3D && scene._THREEcamera) {
+              this._THREErenderer.render(
+                  scene._THREEObject3D,
+                  scene._THREEcamera
+              );
+          }
+        });
+
+    },
+
+    render() {
+        if (this.props.canvas) return null;
+
+        // the three.js renderer will get applied to this canvas element
+        return React.createElement("canvas");
+    }
+});
+
+module.exports = THREERenderer;

--- a/src/components/THREEScene.js
+++ b/src/components/THREEScene.js
@@ -26,14 +26,16 @@ var THREEScene = React.createClass({
         enableRapidRender: React.PropTypes.bool,
         pixelRatio: React.PropTypes.number,
         pointerEvents: React.PropTypes.arrayOf(React.PropTypes.string),
-        transparent: React.PropTypes.bool
+        transparent: React.PropTypes.bool,
+        disableHotLoader: React.PropTypes.bool
     },
 
     getDefaultProps() {
         return {
             enableRapidRender: true,
             pixelRatio: 1,
-            transparent: false
+            transparent: false,
+            disableHotLoader: false
         };
     },
 
@@ -98,7 +100,9 @@ var THREEScene = React.createClass({
         );
         ReactUpdates.ReactReconcileTransaction.release(transaction);
         // hack for react-hot-loader
-        this._reactInternalInstance._renderedComponent._renderedChildren = this._renderedChildren;
+        if (!this.props.disableHotLoader) {
+          this._reactInternalInstance._renderedComponent._renderedChildren = this._renderedChildren;
+        }
 
         // can't look for refs until children get mounted
         var camera = props.camera;
@@ -210,7 +214,9 @@ var THREEScene = React.createClass({
         );
         ReactUpdates.ReactReconcileTransaction.release(transaction);
         // hack for react-hot-loader
-        this._reactInternalInstance._renderedComponent._renderedChildren = this._renderedChildren;
+        if (!this.props.disableHotLoader) {
+          this._reactInternalInstance._renderedComponent._renderedChildren = this._renderedChildren;
+        }
 
         if (typeof props.camera === 'string') {
             this._THREEcamera = this._THREEObject3D.getObjectByName(props.camera);
@@ -225,7 +231,9 @@ var THREEScene = React.createClass({
 
     componentWillUnmount() {
         // hack for react-hot-loader
-        this._reactInternalInstance._renderedComponent._renderedChildren = null;
+        if (!this.props.disableHotLoader) {
+          this._reactInternalInstance._renderedComponent._renderedChildren = null;
+        }
         this.unmountChildren();
         ReactBrowserEventEmitter.deleteAllListeners(this._reactInternalInstance._rootNodeID);
         if (typeof this._rAFID !== 'undefined') {

--- a/src/mixins/THREEContainerMixin.js
+++ b/src/mixins/THREEContainerMixin.js
@@ -11,6 +11,8 @@ var THREEContainerMixin = assign({},  ReactMultiChild.Mixin, {
         var childTHREEObject3D = child._mountImage; // should be a three.js Object3D
         var THREEObject3D = this._THREEObject3D;
 
+        if (!THREEObject3D) return; // for THREERenderer, which has no _THREEObject3D
+
         var childindex = THREEObject3D.children.indexOf(childTHREEObject3D);
         if (childindex === -1) {
             throw new Error('The object to move needs to already be a child');
@@ -53,12 +55,15 @@ var THREEContainerMixin = assign({},  ReactMultiChild.Mixin, {
             context
         );
         // Each mount image corresponds to one of the flattened children
+        const thisTHREEObject3D = this._THREEObject3D;
         var i = 0;
         for (var key in this._renderedChildren) {
             if (this._renderedChildren.hasOwnProperty(key)) {
                 var child = this._renderedChildren[key];
                 child._mountImage = mountedImages[i];
-                this._THREEObject3D.add(child._mountImage);
+
+                // THREERenderer has no _THREEObject3D
+                if (thisTHREEObject3D) thisTHREEObject3D.add(child._mountImage);
                 i++;
             }
         }


### PR DESCRIPTION
The basic idea is to go from this:

```jsx
<Scene>{/*...*/}</Scene>
```
to this:
```jsx
<Renderer>
 <Scene>{/*...*/}</Scene>
 <Scene>{/*...*/}</Scene>
</Renderer>
```

It could probably use improvement, but looking for feedback on this. This came about because I want to [render a second scene as a background](http://stackoverflow.com/questions/19865537/three-js-set-background-image).

Do you like this general approach? 

I refactored the *cupcake* example to use this approach. The rest of the examples would also need to be refactored. 

note: #59 should be merged first

Here's the cupcake demo. Note that each cupcake is inside of it's own Scene:

![2cupcakes](https://cloud.githubusercontent.com/assets/2136203/11171501/92b78f9e-8ba6-11e5-8887-ced8c72d6afe.gif)