### PR TITLE
add dev dependency on jasmine-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-runtime": "^5.8.20",
     "eslint": "^1.4.0",
     "expose-loader": "^0.7.0",
+    "jasmine-core": "^2.3.4",
     "karma": "~0.13.0",
     "karma-chrome-launcher": "~0.1.3",
     "karma-firefox-launcher": "~0.1.3",


### PR DESCRIPTION
Fixes "Error: Cannot find module 'jasmine-core'" when running npm test.