### PR TITLE
Adding rotation prop to Object3D

### DIFF
--- a/src/mixins/THREEObject3DMixin.js
+++ b/src/mixins/THREEObject3DMixin.js
@@ -41,6 +41,12 @@ var THREEObject3DMixin = assign({}, THREEContainerMixin, {
             THREEObject3D.quaternion.set(0,0,0,1); // no rotation
         }
 
+        if (typeof props.rotation !== 'undefined') {
+            THREEObject3D.rotation.copy(props.rotation);
+        } else {
+            THREEObject3D.rotation.set(0,0,0,'XYZ'); // no rotation
+        }
+
         if (typeof props.visible !== 'undefined') {
             THREEObject3D.visible = props.visible;
         } else {


### PR DESCRIPTION
I noticed that only quaternions are supported for Object3Ds, while threejs supports both quats and eulers (via the rotation property). This simply adds that property.