### PR TITLE
Fixed issue with quaternion rotations being overwritten

### DIFF
--- a/src/mixins/THREEObject3DMixin.js
+++ b/src/mixins/THREEObject3DMixin.js
@@ -39,14 +39,10 @@ var THREEObject3DMixin = assign({}, THREEContainerMixin, {
 
     if (typeof props.quaternion !== 'undefined') {
       THREEObject3D.quaternion.copy(props.quaternion);
-    } else {
-      THREEObject3D.quaternion.set(0,0,0,1); // no rotation
-    }
-
-    if (typeof props.rotation !== 'undefined') {
+    } else if (typeof props.rotation !== 'undefined') {
       THREEObject3D.rotation.copy(props.rotation);
     } else {
-      THREEObject3D.rotation.set(0,0,0,'XYZ'); // no rotation
+      THREEObject3D.quaternion.set(0,0,0,1); // no rotation
     }
 
     if (typeof props.visible !== 'undefined') {


### PR DESCRIPTION
With the introduction of the `rotation` property in #65, setting the `quaternion` property on 3D objects no longer has any effect. This is because the object's rotation gets reset back to nothing on [this line](https://github.com/Izzimach/react-three/blob/master/src/mixins/THREEObject3DMixin.js#L49).

This PR changes the behavior to look first for the `quaternion` property, then the `rotation` property, and only when neither are present does it reset the rotation.