### PR TITLE
Upgrades three dependency to ^0.84.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
-    "three": "^0.74.0"
+    "three": "^0.84.0"
   },
   "devDependencies": {
     "babel-core": "^6.0.0",
@@ -56,7 +56,7 @@
     "react-dom": "^15.4.1",
     "resemblejs": "^2.2.0",
     "rimraf": "~2.5.0",
-    "three": "^0.74.0",
+    "three": "^0.84.0",
     "webpack": "^1.12.1",
     "webpack-dev-server": "~1.14.1"
   },

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+var THREE = require('three');
 
 export default {
 

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+var THREE = require('three');
 import assign from 'object-assign';
 import warning from 'fbjs/lib/warning';
 

--- a/src/components/THREERenderer.js
+++ b/src/components/THREERenderer.js
@@ -3,7 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactUpdates from 'react-dom/lib/ReactUpdates';
 import warning from 'fbjs/lib/warning';
-import THREE from 'three';
+var THREE = require('three');
 import THREEContainerMixin from '../mixins/THREEContainerMixin';
 
 import EventPluginHub from 'react-dom/lib/EventPluginHub';

--- a/src/components/THREEScene.js
+++ b/src/components/THREEScene.js
@@ -2,7 +2,7 @@ import ReactMount from 'react-dom/lib/ReactMount';
 import { listenTo } from 'react-dom/lib/ReactBrowserEventEmitter';
 import EventPluginHub from 'react-dom/lib/EventPluginHub';
 
-import THREE from 'three';
+var THREE = require('three');
 import THREEObject3DMixin from '../mixins/THREEObject3DMixin';
 import {createTHREEComponent} from '../Utils';
 

--- a/src/components/cameras/THREEOrthographicCamera.js
+++ b/src/components/cameras/THREEOrthographicCamera.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+var THREE = require('three');
 import { createTHREEComponent } from '../../Utils';
 import THREEObject3DMixin from '../../mixins/THREEObject3DMixin';
 

--- a/src/components/cameras/THREEPerspectiveCamera.js
+++ b/src/components/cameras/THREEPerspectiveCamera.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+var THREE = require('three');
 import { createTHREEComponent } from '../../Utils';
 import THREEObject3DMixin from '../../mixins/THREEObject3DMixin';
 

--- a/src/components/extras/THREEDecoratorHelper.js
+++ b/src/components/extras/THREEDecoratorHelper.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+var THREE = require('three');
 import { createTHREEComponent } from '../../Utils';
 import THREEObject3DMixin from '../../mixins/THREEObject3DMixin';
 import _ from 'lodash';

--- a/src/components/lights/THREEAmbientLight.js
+++ b/src/components/lights/THREEAmbientLight.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+var THREE = require('three');
 import { createTHREEComponent } from '../../Utils';
 import THREEObject3DMixin from '../../mixins/THREEObject3DMixin';
 import LightObjectMixin from '../../mixins/LightObjectMixin';

--- a/src/components/lights/THREEAreaLight.js
+++ b/src/components/lights/THREEAreaLight.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+var THREE = require('three');
 import { createTHREEComponent } from '../../Utils';
 import THREEObject3DMixin from '../../mixins/THREEObject3DMixin';
 import LightObjectMixin from '../../mixins/LightObjectMixin';

--- a/src/components/lights/THREEDirectionalLight.js
+++ b/src/components/lights/THREEDirectionalLight.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+var THREE = require('three');
 import { createTHREEComponent } from '../../Utils';
 import THREEObject3DMixin from '../../mixins/THREEObject3DMixin';
 import LightObjectMixin from '../../mixins/LightObjectMixin';

--- a/src/components/lights/THREEHemisphereLight.js
+++ b/src/components/lights/THREEHemisphereLight.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+var THREE = require('three');
 import {createTHREEComponent, setNewLightColor} from '../../Utils';
 import THREEObject3DMixin from '../../mixins/THREEObject3DMixin';
 import LightObjectMixin from '../../mixins/LightObjectMixin';

--- a/src/components/lights/THREEPointLight.js
+++ b/src/components/lights/THREEPointLight.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+var THREE = require('three');
 import { createTHREEComponent } from '../../Utils';
 import THREEObject3DMixin from '../../mixins/THREEObject3DMixin';
 import LightObjectMixin from '../../mixins/LightObjectMixin';

--- a/src/components/objects/THREEAxisHelper.js
+++ b/src/components/objects/THREEAxisHelper.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+var THREE = require('three');
 import { createTHREEComponent } from '../../Utils';
 import THREEObject3DMixin from '../../mixins/THREEObject3DMixin';
 

--- a/src/components/objects/THREELine.js
+++ b/src/components/objects/THREELine.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+var THREE = require('three');
 import { createTHREEComponent } from '../../Utils';
 import THREEObject3DMixin from '../../mixins/THREEObject3DMixin';
 

--- a/src/components/objects/THREELineSegments.js
+++ b/src/components/objects/THREELineSegments.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+var THREE = require('three');
 import { createTHREEComponent } from '../../Utils';
 import THREEObject3DMixin from '../../mixins/THREEObject3DMixin';
 

--- a/src/components/objects/THREEMesh.js
+++ b/src/components/objects/THREEMesh.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+var THREE = require('three');
 import { createTHREEComponent } from '../../Utils';
 import THREEObject3DMixin from '../../mixins/THREEObject3DMixin';
 

--- a/src/components/objects/THREEPointCloud.js
+++ b/src/components/objects/THREEPointCloud.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+var THREE = require('three');
 import { createTHREEComponent } from '../../Utils';
 import THREEObject3DMixin from '../../mixins/THREEObject3DMixin';
 

--- a/src/components/objects/THREESkinnedMesh.js
+++ b/src/components/objects/THREESkinnedMesh.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+var THREE = require('three');
 import { createTHREEComponent } from '../../Utils';
 import THREEObject3DMixin from '../../mixins/THREEObject3DMixin';
 

--- a/src/components/objects/THREESprite.js
+++ b/src/components/objects/THREESprite.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+var THREE = require('three');
 import { createTHREEComponent } from '../../Utils';
 import THREEObject3DMixin from '../../mixins/THREEObject3DMixin';
 

--- a/src/mixins/THREEObject3DMixin.js
+++ b/src/mixins/THREEObject3DMixin.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+var THREE = require('three');
 import assign from 'object-assign';
 import THREEContainerMixin from './THREEContainerMixin';
 import warning from 'fbjs/lib/warning';


### PR DESCRIPTION
At some point between 0.74 and 0.84, the `three` package became an actual ES Module, with an `__esModule: true` flag. This caused the webpack process for the `build-commonjs` process to generate bad code. The simplest solution seemed like just changing the import statements to require statements.